### PR TITLE
Add Apple tags in <head>. Because it can’t manifest 😒

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -11,7 +11,10 @@
     <meta property="og:description" content="<!-- APP_DESCRIPTION -->">
     <meta property="og:image" content="<!-- BASE_URL -->icon-512.png">
     <link rel="icon" type="image/png" href="./icon-32.png">
-    <meta name="theme-color" content="<!-- STATUS_BG -->">
+    <link rel="apple-touch-icon" href="./icon-192.png">
+    <meta name="theme-color" content="<!-- STATUS_BG -->" data-status-bg>
+    <meta name="apple-mobile-web-app-status-bar-style" content="<!-- STATUS_BG -->" data-status-bg>
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta http-equiv="refresh" content="<!-- CHECK_INTERVAL -->">
     <link rel="stylesheet" href="./index.css">
   </head>

--- a/static/index.mjs
+++ b/static/index.mjs
@@ -20,7 +20,7 @@ const WEB_PUSH_SUPPORTED =
     && typeof window.PushManager.prototype.subscribe === 'function';
 const PUSH_SUPPORTED = WEB_PUSH_SUPPORTED;
 
-const themeColor = document.querySelector('meta[name="theme-color"]');
+const statusBgMetas = document.querySelectorAll('meta[data-status-bg]');
 const main = document.getElementsByTagName('main')[0];
 const output = document.getElementsByTagName('output')[0];
 const subscribe = document.getElementById('subscribe');
@@ -199,7 +199,11 @@ function reflectStatus (status)
     subscribe.hidden = status !== statuses.OCCUPIED;
     subscribe.disabled = !!subscribed;
 
-    themeColor.content = window.getComputedStyle(main).backgroundColor;
+    const statusBgColour = window.getComputedStyle(main).backgroundColor;
+    for (const meta of statusBgMetas)
+    {
+        meta.content = statusBgColour;
+    }
 }
 
 function getClientId ()


### PR DESCRIPTION
# Why?

Closes https://github.com/DietLabs/okupando/issues/22
Adding site to home screen on mobile safari sends requests for `apple-touch-icon-120x120-precomposed.png` et al.


# What?

Besides icon this PR adds:

1. `<meta name="apple-mobile-web-app-capable" content="yes">`, bacause safari can’t read `display` from manifest

2. `<meta name="apple-mobile-web-app-status-bar-style" content="#0f0>`, but it doesn’t seem to be working :disappointed: 


# So?…

Would be grateful for help with that `🍎📱🕸app-status-bar-style`.